### PR TITLE
Added category for 3d print section with Snapsplit Addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ English | [简体中文版 (Chinese)](README_ZH.md)
 
 ### 🖨️3D print [^](#table)
 - [Snapsplit](https://github.com/Betakontext/snapsplit) : Automates cut and connection building workflows for complex 3D models in Blender, which are f.e. larger than your printing bed, to create printable parts. It generates precise, glue-free snap-fit connectors.
+- [3D Print Toolbox](https://extensions.blender.org/add-ons/print3d-toolbox/) : Must-have utilities to clean and prepare models for 3d printing in Blender.
 
 ### 🗜Render Engine [^](#table)
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ English | [简体中文版 (Chinese)](README_ZH.md)
     - [TextCounter](https://github.com/leomoon-studios/leomoon-textcounter/) : LeoMoon TextCounter is an easy to use text animation plugin for Blender that can be used to make GUI simulations.
     - [GreaseWriter](https://github.com/doakey3/GreaseWriter) : A Blender Add-on for auto-animating grease pencil strokes and emulating hand-drawn text.
 
+### 🗜3D print [^](#table)
+- [Snapsplit](https://github.com/Betakontext/snapsplit) : Automates cut and connection building workflows for complex 3D models in Blender, which are f.e. larger than your printing bed, to create printable parts. It generates precise, glue-free snap-fit connectors.
+
 ### 🗜Render Engine [^](#table)
 
 - [AMD Radeon ProRender](https://www.amd.com/en/technologies/radeon-prorender-blender) : is AMD’s powerful physically-based rendering engine that lets creative professionals use open industry standards to leverage GPU and CPU performance to produce stunningly photorealistic images in Blender.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ English | [简体中文版 (Chinese)](README_ZH.md)
     - [TextCounter](https://github.com/leomoon-studios/leomoon-textcounter/) : LeoMoon TextCounter is an easy to use text animation plugin for Blender that can be used to make GUI simulations.
     - [GreaseWriter](https://github.com/doakey3/GreaseWriter) : A Blender Add-on for auto-animating grease pencil strokes and emulating hand-drawn text.
 
-### 🗜3D print [^](#table)
+### 🖨️3D print [^](#table)
 - [Snapsplit](https://github.com/Betakontext/snapsplit) : Automates cut and connection building workflows for complex 3D models in Blender, which are f.e. larger than your printing bed, to create printable parts. It generates precise, glue-free snap-fit connectors.
 
 ### 🗜Render Engine [^](#table)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -454,6 +454,7 @@
 ---
 ### 🖨️ 3D打印 [^](#table)
 - [Snapsplit](https://github.com/Betakontext/snapsplit)：可自动完成Blender中复杂3D模型的切割和连接构建工作流程（例如，大于您的打印平台的模型），以创建可打印的部件。它能生成精确、无需胶水的卡扣式连接件。
+- [3d Print Toolbox](https://extensions.blender.org/add-ons/print3d-toolbox/): 用于在 Blender 中清洁和准备模型以进行 3D 打印的基本实用程序。
 
 ## 🪐 资源 [^](#table)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -452,6 +452,8 @@
 - [AI Render](https://github.com/benrugg/AI-Render)：Blender中的稳定扩散。这个插件根据文本提示和您的场景渲染AI生成的图像。
 
 ---
+### 🖨️ 3D打印 [^](#table)
+- [Snapsplit](https://github.com/Betakontext/snapsplit)：可自动完成Blender中复杂3D模型的切割和连接构建工作流程（例如，大于您的打印平台的模型），以创建可打印的部件。它能生成精确、无需胶水的卡扣式连接件。
 
 ## 🪐 资源 [^](#table)
 


### PR DESCRIPTION
Added category for 3d print with Snapsplit Addon, to automate cutting and connection building workflows for f.e. models bigger than your printing bed in Blender